### PR TITLE
🐛 Fix error deserialization

### DIFF
--- a/src/base_error.ts
+++ b/src/base_error.ts
@@ -46,7 +46,7 @@ export class BaseError extends Error {
       throw new Error(`Error while deserializing an essential-projects-error: ${errorInfo.errorClassName} is not a known essential-projects-error`);
     }
 
-    const errorClass: BaseError = new errorClasses[errorInfo.errorClassName](errorInfo.code, errorInfo.message);
+    const errorClass: BaseError = new errorClasses[errorInfo.errorClassName](errorInfo.message);
     errorClass.stack = errorInfo.callStack;
     errorClass.additionalInformation = errorInfo.additionalInformation;
 


### PR DESCRIPTION
**Changes:**

The `deserialize` function of the `BaseError` passed two arguments to the created Error-Instances - the error code, followed by the error message.
However, all the error types only expect a message as parameter.
This resulted in the deserialized errors having the error code assigned as the error message. 

To fix this, the first parameter was removed from the constructor calls.

**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/309

PR: #19

## How can others test the changes?

Call `BaseError.deserialize` with a serialized error from `@essential-projects/errors_ts` and see that it gets resolved correctly.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).